### PR TITLE
Wagtail 7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ StreamField([
 ### Customizing the widget's display and behaviour
 
 ```python
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
 from instance_selector.registry import registry
 from instance_selector.selectors import ModelAdminInstanceSelector
 from .models import MyModel

--- a/example/example_app/__init__.py
+++ b/example/example_app/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "%s.apps.AppConfig" % __name__

--- a/example/example_app/wagtail_hooks.py
+++ b/example/example_app/wagtail_hooks.py
@@ -1,8 +1,10 @@
 from django.utils.safestring import mark_safe
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
+
 from instance_selector.registry import registry
 from instance_selector.selectors import ModelAdminInstanceSelector
-from .models import Shop, Product, Image
+
+from .models import Image, Product, Shop
 
 
 @modeladmin_register

--- a/example/example_project/settings.py
+++ b/example/example_project/settings.py
@@ -39,7 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "wagtail.admin",
     "wagtail",
-    "wagtail.contrib.modeladmin",
+    "wagtail_modeladmin",
     "wagtail.contrib.settings",
     "wagtail.users",
     "wagtail.documents",

--- a/example/example_project/settings.py
+++ b/example/example_project/settings.py
@@ -25,7 +25,7 @@ SECRET_KEY = "(#(!pj=@l5e6aiq8($950frv%*_e=s*a5-1ne$qu(u_b053wr("
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
@@ -113,7 +113,6 @@ TIME_ZONE = "UTC"
 
 USE_I18N = True
 
-USE_L10N = True
 
 USE_TZ = True
 

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,3 +1,4 @@
 django>=3.2
-wagtail>=4.1
+wagtail>=5.2
+wagtail-modeladmin==2.0.0
 wagtail-instance-selector

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,4 +1,4 @@
-django>=3.2
-wagtail>=5.2
-wagtail-modeladmin==2.0.0
+django>=4.2
+wagtail>=6.3
+wagtail-modeladmin>=2.0
 wagtail-instance-selector

--- a/instance_selector/blocks.py
+++ b/instance_selector/blocks.py
@@ -1,3 +1,4 @@
+from django import forms
 from django.utils.functional import cached_property, lazy
 
 from instance_selector.widgets import InstanceSelectorWidget
@@ -11,6 +12,7 @@ from wagtail.blocks.field_block import FieldBlockAdapter
 
 
 class InstanceSelectorBlock(ChooserBlock):
+    widget = forms.TextInput  # Dummy widget to satisfy Wagtail internals
     class Meta:
         icon = "placeholder"
 
@@ -28,12 +30,9 @@ class InstanceSelectorBlock(ChooserBlock):
     def target_model(self):
         return resolve_model_string(self._target_model)
 
-    @cached_property
-    def widget(self):
-        return InstanceSelectorWidget(self.target_model)
-
     def get_form_state(self, value):
-        return self.widget.get_value_data(value)
+        widget = InstanceSelectorWidget(self.target_model)
+        return widget.get_value_data(value)
 
     def get_instance_selector_icon(self):
         instance_selector = registry.get_instance_selector(self.target_model)

--- a/instance_selector/static/instance_selector/instance-selector-controller.js
+++ b/instance_selector/static/instance_selector/instance-selector-controller.js
@@ -1,0 +1,12 @@
+// intance_selector/static/intance_selector/instance-selector-controller.js
+
+class InstanceSelectorController extends window.StimulusModule.Controller {
+    static values = { config: Object };
+
+    connect() {
+        create_instance_selector_widget(this.configValue);
+        console.log(this.configValue);
+    }
+}
+
+window.wagtail.app.register('instance-selector', InstanceSelectorController);

--- a/instance_selector/static/instance_selector/instance-selector-controller.js
+++ b/instance_selector/static/instance_selector/instance-selector-controller.js
@@ -1,5 +1,3 @@
-// intance_selector/static/intance_selector/instance-selector-controller.js
-
 class InstanceSelectorController extends window.StimulusModule.Controller {
     static values = { config: Object };
 

--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -1,132 +1,283 @@
 import json
+
 from django.forms import widgets
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from instance_selector.constants import OBJECT_PK_PARAM
-from instance_selector.registry import registry
-
+from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.telepath import register
 from wagtail.utils.widgets import WidgetWithScript
 from wagtail.widget_adapters import WidgetAdapter
 
+from instance_selector.constants import OBJECT_PK_PARAM
+from instance_selector.registry import registry
 
-class InstanceSelectorWidget(WidgetWithScript, widgets.Input):
-    # when looping over form fields, this one should appear in visible_fields, not hidden_fields
-    # despite the underlying input being type="hidden"
-    input_type = "hidden"
-    is_hidden = False
+if WAGTAIL_VERSION >= (6, 0):
+    from django.forms import Media
+    from django.utils.safestring import mark_safe
 
-    def __init__(self, model, **kwargs):
-        self.target_model = model
+    class InstanceSelectorWidget(widgets.Input):
+        # when looping over form fields, this one should appear in visible_fields, not hidden_fields
+        # despite the underlying input being type="hidden"
+        input_type = "hidden"
+        is_hidden = False
 
-        model_name = self.target_model._meta.verbose_name
-        self.choose_one_text = _("Choose %s") % model_name
-        self.choose_another_text = _("Choose another %s") % model_name
-        self.link_to_chosen_text = _("Edit this %s") % model_name
-        self.clear_choice_text = _("Clear choice")
-        self.show_edit_link = True
-        self.show_clear_link = True
+        def __init__(self, model, **kwargs):
+            self.target_model = model
 
-        super().__init__(**kwargs)
+            model_name = self.target_model._meta.verbose_name
+            self.choose_one_text = _("Choose %s") % model_name
+            self.choose_another_text = _("Choose another %s") % model_name
+            self.link_to_chosen_text = _("Edit this %s") % model_name
+            self.clear_choice_text = _("Clear choice")
+            self.show_edit_link = True
+            self.show_clear_link = True
 
-    def get_value_data(self, value):
-        # Given a data value (which may be None, a model instance, or a PK here),
-        # extract the necessary data for rendering the widget with that value.
-        # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
-        # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
-        # cannot include model instances. Instead, we return the raw values used in rendering -
-        # namely: pk, display_markup and edit_url
+            super().__init__(**kwargs)
 
-        if not str(value).strip(): # value might be "" (Wagtail 5.0+)
-            value = None
+        def render(self, name, value, attrs=None, renderer=None):
+            # no point trying to come up with sensible semantics for when 'id' is missing from attrs,
+            # so let's make sure it fails early in the process
 
-        if value is None or isinstance(value, self.target_model):
-            instance = value
-        else:  # assume this is an instance ID
-            instance = self.target_model.objects.get(pk=value)
+            self.name = name
+            try:
+                self.id_ = attrs["id"]
+            except (KeyError, TypeError):
+                raise TypeError(
+                    "WidgetWithScript cannot be rendered without an 'id' attribute"
+                )
 
-        app_label = self.target_model._meta.app_label
-        model_name = self.target_model._meta.model_name
-        model = registry.get_model(app_label, model_name)
-        instance_selector = registry.get_instance_selector(model)
-        display_markup = instance_selector.get_instance_display_markup(instance)
-        edit_url = instance_selector.get_instance_edit_url(instance)
+            value_data = self.get_value_data(value)
+            widget_html = self.render_html(name, value_data, attrs)
 
-        return {
-            "pk": instance.pk if instance else None,
-            "display_markup": display_markup,
-            "edit_url": edit_url,
-        }
+            return mark_safe(widget_html)
 
-    def render_html(self, name, value, attrs):
-        value_data = value
-        
-        original_field_html = super().render_html(name, value_data["pk"], attrs)
+        def get_value_data(self, value):
+            # Given a data value (which may be None, a model instance, or a PK here),
+            # extract the necessary data for rendering the widget with that value.
+            # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
+            # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
+            # cannot include model instances. Instead, we return the raw values used in rendering -
+            # namely: pk, display_markup and edit_url
 
-        app_label = self.target_model._meta.app_label
-        model_name = self.target_model._meta.model_name
+            if not str(value).strip():  # value might be "" (Wagtail 5.0+)
+                value = None
 
-        embed_url = reverse(
-            "wagtail_instance_selector_embed",
-            kwargs={"app_label": app_label, "model_name": model_name},
-        )
-        # We use the input name for the embed id so that wagtail's block code will automatically
-        # replace any `__prefix__` substring with a specific id for the widget instance
-        embed_id = name
-        embed_url += "#instance_selector_embed_id:" + embed_id
+            if value is None or isinstance(value, self.target_model):
+                instance = value
+            else:  # assume this is an instance ID
+                instance = self.target_model.objects.get(pk=value)
 
-        lookup_url = reverse(
-            "wagtail_instance_selector_lookup",
-            kwargs={"app_label": app_label, "model_name": model_name},
-        )
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+            model = registry.get_model(app_label, model_name)
+            instance_selector = registry.get_instance_selector(model)
+            display_markup = instance_selector.get_instance_display_markup(instance)
+            edit_url = instance_selector.get_instance_edit_url(instance)
 
-        return render_to_string(
-            "instance_selector/instance_selector_widget.html",
-            {
-                "name": name,
-                "is_nonempty": value_data["pk"] is not None,
-                "widget": self,
-                "widget_id": "%s-instance-selector-widget" % attrs["id"],
-                "original_field_html": original_field_html,
-                "display_markup": value_data["display_markup"],
-                "edit_url": value_data["edit_url"],
-            },
-        )
+            return {
+                "pk": instance.pk if instance else None,
+                "display_markup": display_markup,
+                "edit_url": edit_url,
+            }
 
-    def get_js_config(self, id_, name):
-        app_label = self.target_model._meta.app_label
-        model_name = self.target_model._meta.model_name
+        def render_html(self, name, value, attrs):
+            value_data = value
 
-        embed_url = reverse(
-            "wagtail_instance_selector_embed",
-            kwargs={"app_label": app_label, "model_name": model_name},
-        )
-        # We use the input name for the embed id so that wagtail's block code will automatically
-        # replace any `__prefix__` substring with a specific id for the widget instance
-        embed_id = name
-        embed_url += "#instance_selector_embed_id:" + embed_id
+            original_field_html = super().render(name, value_data["pk"], attrs)
 
-        lookup_url = reverse(
-            "wagtail_instance_selector_lookup",
-            kwargs={"app_label": app_label, "model_name": model_name},
-        )
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
 
-        return {
-            "input_id": id_,
-            "widget_id": "%s-instance-selector-widget" % id_,
-            "field_name": name,
-            "embed_url": embed_url,
-            "embed_id": embed_id,
-            "lookup_url": lookup_url,
-            "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
-        }
+            embed_url = reverse(
+                "wagtail_instance_selector_embed",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+            # We use the input name for the embed id so that wagtail's block code will automatically
+            # replace any `__prefix__` substring with a specific id for the widget instance
+            embed_id = name
+            embed_url += "#instance_selector_embed_id:" + embed_id
 
-    def render_js_init(self, id_, name, value):
-        config = self.get_js_config(id_, name)
-        return "create_instance_selector_widget({config});".format(
-            config=json.dumps(config)
-        )
+            lookup_url = reverse(
+                "wagtail_instance_selector_lookup",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+
+            return render_to_string(
+                "instance_selector/instance_selector_widget.html",
+                {
+                    "name": name,
+                    "is_nonempty": value_data["pk"] is not None,
+                    "widget": self,
+                    "widget_id": "%s-instance-selector-widget" % attrs["id"],
+                    "original_field_html": original_field_html,
+                    "display_markup": value_data["display_markup"],
+                    "edit_url": value_data["edit_url"],
+                },
+            )
+
+        def get_js_config(self, id_, name):
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+
+            embed_url = reverse(
+                "wagtail_instance_selector_embed",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+            # We use the input name for the embed id so that wagtail's block code will automatically
+            # replace any `__prefix__` substring with a specific id for the widget instance
+            embed_id = name
+            embed_url += "#instance_selector_embed_id:" + embed_id
+
+            lookup_url = reverse(
+                "wagtail_instance_selector_lookup",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+
+            return {
+                "input_id": id_,
+                "widget_id": "%s-instance-selector-widget" % id_,
+                "field_name": name,
+                "embed_url": embed_url,
+                "embed_id": embed_id,
+                "lookup_url": lookup_url,
+                "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
+            }
+
+        def build_attrs(self, *args, **kwargs):
+            attrs = super().build_attrs(*args, **kwargs)
+            attrs["data-controller"] = "instance-selector"
+            attrs["data-instance-selector-config-value"] = json.dumps(
+                self.get_js_config(self.id_, self.name)
+            )
+            return attrs
+
+        @property
+        def media(self):
+            return Media(
+                js=[
+                    "instance_selector/instance-selector-controller.js",
+                ]
+            )
+
+else:
+
+    class InstanceSelectorWidget(WidgetWithScript, widgets.Input):
+        # when looping over form fields, this one should appear in visible_fields, not hidden_fields
+        # despite the underlying input being type="hidden"
+        input_type = "hidden"
+        is_hidden = False
+
+        def __init__(self, model, **kwargs):
+            self.target_model = model
+
+            model_name = self.target_model._meta.verbose_name
+            self.choose_one_text = _("Choose %s") % model_name
+            self.choose_another_text = _("Choose another %s") % model_name
+            self.link_to_chosen_text = _("Edit this %s") % model_name
+            self.clear_choice_text = _("Clear choice")
+            self.show_edit_link = True
+            self.show_clear_link = True
+
+            super().__init__(**kwargs)
+
+        def get_value_data(self, value):
+            # Given a data value (which may be None, a model instance, or a PK here),
+            # extract the necessary data for rendering the widget with that value.
+            # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
+            # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
+            # cannot include model instances. Instead, we return the raw values used in rendering -
+            # namely: pk, display_markup and edit_url
+
+            if not str(value).strip():  # value might be "" (Wagtail 5.0+)
+                value = None
+
+            if value is None or isinstance(value, self.target_model):
+                instance = value
+            else:  # assume this is an instance ID
+                instance = self.target_model.objects.get(pk=value)
+
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+            model = registry.get_model(app_label, model_name)
+            instance_selector = registry.get_instance_selector(model)
+            display_markup = instance_selector.get_instance_display_markup(instance)
+            edit_url = instance_selector.get_instance_edit_url(instance)
+
+            return {
+                "pk": instance.pk if instance else None,
+                "display_markup": display_markup,
+                "edit_url": edit_url,
+            }
+
+        def render_html(self, name, value, attrs):
+            value_data = value
+
+            original_field_html = super().render_html(name, value_data["pk"], attrs)
+
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+
+            embed_url = reverse(
+                "wagtail_instance_selector_embed",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+            # We use the input name for the embed id so that wagtail's block code will automatically
+            # replace any `__prefix__` substring with a specific id for the widget instance
+            embed_id = name
+            embed_url += "#instance_selector_embed_id:" + embed_id
+
+            lookup_url = reverse(
+                "wagtail_instance_selector_lookup",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+
+            return render_to_string(
+                "instance_selector/instance_selector_widget.html",
+                {
+                    "name": name,
+                    "is_nonempty": value_data["pk"] is not None,
+                    "widget": self,
+                    "widget_id": "%s-instance-selector-widget" % attrs["id"],
+                    "original_field_html": original_field_html,
+                    "display_markup": value_data["display_markup"],
+                    "edit_url": value_data["edit_url"],
+                },
+            )
+
+        def get_js_config(self, id_, name):
+            app_label = self.target_model._meta.app_label
+            model_name = self.target_model._meta.model_name
+
+            embed_url = reverse(
+                "wagtail_instance_selector_embed",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+            # We use the input name for the embed id so that wagtail's block code will automatically
+            # replace any `__prefix__` substring with a specific id for the widget instance
+            embed_id = name
+            embed_url += "#instance_selector_embed_id:" + embed_id
+
+            lookup_url = reverse(
+                "wagtail_instance_selector_lookup",
+                kwargs={"app_label": app_label, "model_name": model_name},
+            )
+
+            return {
+                "input_id": id_,
+                "widget_id": "%s-instance-selector-widget" % id_,
+                "field_name": name,
+                "embed_url": embed_url,
+                "embed_id": embed_id,
+                "lookup_url": lookup_url,
+                "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
+            }
+
+        def render_js_init(self, id_, name, value):
+            config = self.get_js_config(id_, name)
+            return "create_instance_selector_widget({config});".format(
+                config=json.dumps(config)
+            )
 
 
 class InstanceSelectorAdapter(WidgetAdapter):

--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -41,7 +41,7 @@ class InstanceSelectorWidget(widgets.Input):
             self.id_ = attrs["id"]
         except (KeyError, TypeError):
             raise TypeError(
-                "WidgetWithScript cannot be rendered without an 'id' attribute"
+                "InstanceSelectorWidget cannot be rendered without an 'id' attribute"
             )
 
         value_data = self.get_value_data(value)

--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -4,279 +4,158 @@ from django.forms import widgets
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.telepath import register
 from wagtail.widget_adapters import WidgetAdapter
 
 from instance_selector.constants import OBJECT_PK_PARAM
 from instance_selector.registry import registry
 
-if WAGTAIL_VERSION >= (6, 0):
-    from django.forms import Media
-    from django.utils.safestring import mark_safe
+from django.forms import Media
+from django.utils.safestring import mark_safe
 
-    class InstanceSelectorWidget(widgets.Input):
-        # when looping over form fields, this one should appear in visible_fields, not hidden_fields
-        # despite the underlying input being type="hidden"
-        input_type = "hidden"
-        is_hidden = False
+class InstanceSelectorWidget(widgets.Input):
+    # when looping over form fields, this one should appear in visible_fields, not hidden_fields
+    # despite the underlying input being type="hidden"
+    input_type = "hidden"
+    is_hidden = False
 
-        def __init__(self, model, **kwargs):
-            self.target_model = model
+    def __init__(self, model, **kwargs):
+        self.target_model = model
 
-            model_name = self.target_model._meta.verbose_name
-            self.choose_one_text = _("Choose %s") % model_name
-            self.choose_another_text = _("Choose another %s") % model_name
-            self.link_to_chosen_text = _("Edit this %s") % model_name
-            self.clear_choice_text = _("Clear choice")
-            self.show_edit_link = True
-            self.show_clear_link = True
+        model_name = self.target_model._meta.verbose_name
+        self.choose_one_text = _("Choose %s") % model_name
+        self.choose_another_text = _("Choose another %s") % model_name
+        self.link_to_chosen_text = _("Edit this %s") % model_name
+        self.clear_choice_text = _("Clear choice")
+        self.show_edit_link = True
+        self.show_clear_link = True
 
-            super().__init__(**kwargs)
+        super().__init__(**kwargs)
 
-        def render(self, name, value, attrs=None, renderer=None):
-            # no point trying to come up with sensible semantics for when 'id' is missing from attrs,
-            # so let's make sure it fails early in the process
+    def render(self, name, value, attrs=None, renderer=None):
+        # no point trying to come up with sensible semantics for when 'id' is missing from attrs,
+        # so let's make sure it fails early in the process
 
-            self.name = name
-            try:
-                self.id_ = attrs["id"]
-            except (KeyError, TypeError):
-                raise TypeError(
-                    "WidgetWithScript cannot be rendered without an 'id' attribute"
-                )
-
-            value_data = self.get_value_data(value)
-            widget_html = self.render_html(name, value_data, attrs)
-
-            return mark_safe(widget_html)
-
-        def get_value_data(self, value):
-            # Given a data value (which may be None, a model instance, or a PK here),
-            # extract the necessary data for rendering the widget with that value.
-            # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
-            # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
-            # cannot include model instances. Instead, we return the raw values used in rendering -
-            # namely: pk, display_markup and edit_url
-
-            if not str(value).strip():  # value might be "" (Wagtail 5.0+)
-                value = None
-
-            if value is None or isinstance(value, self.target_model):
-                instance = value
-            else:  # assume this is an instance ID
-                instance = self.target_model.objects.get(pk=value)
-
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
-            model = registry.get_model(app_label, model_name)
-            instance_selector = registry.get_instance_selector(model)
-            display_markup = instance_selector.get_instance_display_markup(instance)
-            edit_url = instance_selector.get_instance_edit_url(instance)
-
-            return {
-                "pk": instance.pk if instance else None,
-                "display_markup": display_markup,
-                "edit_url": edit_url,
-            }
-
-        def render_html(self, name, value, attrs):
-            value_data = value
-
-            original_field_html = super().render(name, value_data["pk"], attrs)
-
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
-
-            embed_url = reverse(
-                "wagtail_instance_selector_embed",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-            # We use the input name for the embed id so that wagtail's block code will automatically
-            # replace any `__prefix__` substring with a specific id for the widget instance
-            embed_id = name
-            embed_url += "#instance_selector_embed_id:" + embed_id
-
-            lookup_url = reverse(
-                "wagtail_instance_selector_lookup",
-                kwargs={"app_label": app_label, "model_name": model_name},
+        self.name = name
+        try:
+            self.id_ = attrs["id"]
+        except (KeyError, TypeError):
+            raise TypeError(
+                "WidgetWithScript cannot be rendered without an 'id' attribute"
             )
 
-            return render_to_string(
-                "instance_selector/instance_selector_widget.html",
-                {
-                    "name": name,
-                    "is_nonempty": value_data["pk"] is not None,
-                    "widget": self,
-                    "widget_id": "%s-instance-selector-widget" % attrs["id"],
-                    "original_field_html": original_field_html,
-                    "display_markup": value_data["display_markup"],
-                    "edit_url": value_data["edit_url"],
-                },
-            )
+        value_data = self.get_value_data(value)
+        widget_html = self.render_html(name, value_data, attrs)
 
-        def get_js_config(self, id_, name):
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
+        return mark_safe(widget_html)
 
-            embed_url = reverse(
-                "wagtail_instance_selector_embed",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-            # We use the input name for the embed id so that wagtail's block code will automatically
-            # replace any `__prefix__` substring with a specific id for the widget instance
-            embed_id = name
-            embed_url += "#instance_selector_embed_id:" + embed_id
+    def get_value_data(self, value):
+        # Given a data value (which may be None, a model instance, or a PK here),
+        # extract the necessary data for rendering the widget with that value.
+        # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
+        # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
+        # cannot include model instances. Instead, we return the raw values used in rendering -
+        # namely: pk, display_markup and edit_url
 
-            lookup_url = reverse(
-                "wagtail_instance_selector_lookup",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
+        if not str(value).strip():  # value might be "" (Wagtail 5.0+)
+            value = None
 
-            return {
-                "input_id": id_,
-                "widget_id": "%s-instance-selector-widget" % id_,
-                "field_name": name,
-                "embed_url": embed_url,
-                "embed_id": embed_id,
-                "lookup_url": lookup_url,
-                "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
-            }
+        if value is None or isinstance(value, self.target_model):
+            instance = value
+        else:  # assume this is an instance ID
+            instance = self.target_model.objects.get(pk=value)
 
-        def build_attrs(self, *args, **kwargs):
-            attrs = super().build_attrs(*args, **kwargs)
-            attrs["data-controller"] = "instance-selector"
-            attrs["data-instance-selector-config-value"] = json.dumps(
-                self.get_js_config(self.id_, self.name)
-            )
-            return attrs
+        app_label = self.target_model._meta.app_label
+        model_name = self.target_model._meta.model_name
+        model = registry.get_model(app_label, model_name)
+        instance_selector = registry.get_instance_selector(model)
+        display_markup = instance_selector.get_instance_display_markup(instance)
+        edit_url = instance_selector.get_instance_edit_url(instance)
 
-        @property
-        def media(self):
-            return Media(
-                js=[
-                    "instance_selector/instance-selector-controller.js",
-                ]
-            )
+        return {
+            "pk": instance.pk if instance else None,
+            "display_markup": display_markup,
+            "edit_url": edit_url,
+        }
 
-else:
-    from wagtail.utils.widgets import WidgetWithScript
-    class InstanceSelectorWidget(WidgetWithScript, widgets.Input):
-        # when looping over form fields, this one should appear in visible_fields, not hidden_fields
-        # despite the underlying input being type="hidden"
-        input_type = "hidden"
-        is_hidden = False
+    def render_html(self, name, value, attrs):
+        value_data = value
 
-        def __init__(self, model, **kwargs):
-            self.target_model = model
+        original_field_html = super().render(name, value_data["pk"], attrs)
 
-            model_name = self.target_model._meta.verbose_name
-            self.choose_one_text = _("Choose %s") % model_name
-            self.choose_another_text = _("Choose another %s") % model_name
-            self.link_to_chosen_text = _("Edit this %s") % model_name
-            self.clear_choice_text = _("Clear choice")
-            self.show_edit_link = True
-            self.show_clear_link = True
+        app_label = self.target_model._meta.app_label
+        model_name = self.target_model._meta.model_name
 
-            super().__init__(**kwargs)
+        embed_url = reverse(
+            "wagtail_instance_selector_embed",
+            kwargs={"app_label": app_label, "model_name": model_name},
+        )
+        # We use the input name for the embed id so that wagtail's block code will automatically
+        # replace any `__prefix__` substring with a specific id for the widget instance
+        embed_id = name
+        embed_url += "#instance_selector_embed_id:" + embed_id
 
-        def get_value_data(self, value):
-            # Given a data value (which may be None, a model instance, or a PK here),
-            # extract the necessary data for rendering the widget with that value.
-            # In the case of StreamField (in Wagtail >=2.13), this data will be serialised via
-            # telepath https://wagtail.github.io/telepath/ to be rendered client-side, which means it
-            # cannot include model instances. Instead, we return the raw values used in rendering -
-            # namely: pk, display_markup and edit_url
+        lookup_url = reverse(
+            "wagtail_instance_selector_lookup",
+            kwargs={"app_label": app_label, "model_name": model_name},
+        )
 
-            if not str(value).strip():  # value might be "" (Wagtail 5.0+)
-                value = None
+        return render_to_string(
+            "instance_selector/instance_selector_widget.html",
+            {
+                "name": name,
+                "is_nonempty": value_data["pk"] is not None,
+                "widget": self,
+                "widget_id": "%s-instance-selector-widget" % attrs["id"],
+                "original_field_html": original_field_html,
+                "display_markup": value_data["display_markup"],
+                "edit_url": value_data["edit_url"],
+            },
+        )
 
-            if value is None or isinstance(value, self.target_model):
-                instance = value
-            else:  # assume this is an instance ID
-                instance = self.target_model.objects.get(pk=value)
+    def get_js_config(self, id_, name):
+        app_label = self.target_model._meta.app_label
+        model_name = self.target_model._meta.model_name
 
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
-            model = registry.get_model(app_label, model_name)
-            instance_selector = registry.get_instance_selector(model)
-            display_markup = instance_selector.get_instance_display_markup(instance)
-            edit_url = instance_selector.get_instance_edit_url(instance)
+        embed_url = reverse(
+            "wagtail_instance_selector_embed",
+            kwargs={"app_label": app_label, "model_name": model_name},
+        )
+        # We use the input name for the embed id so that wagtail's block code will automatically
+        # replace any `__prefix__` substring with a specific id for the widget instance
+        embed_id = name
+        embed_url += "#instance_selector_embed_id:" + embed_id
 
-            return {
-                "pk": instance.pk if instance else None,
-                "display_markup": display_markup,
-                "edit_url": edit_url,
-            }
+        lookup_url = reverse(
+            "wagtail_instance_selector_lookup",
+            kwargs={"app_label": app_label, "model_name": model_name},
+        )
 
-        def render_html(self, name, value, attrs):
-            value_data = value
+        return {
+            "input_id": id_,
+            "widget_id": "%s-instance-selector-widget" % id_,
+            "field_name": name,
+            "embed_url": embed_url,
+            "embed_id": embed_id,
+            "lookup_url": lookup_url,
+            "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
+        }
 
-            original_field_html = super().render_html(name, value_data["pk"], attrs)
+    def build_attrs(self, *args, **kwargs):
+        attrs = super().build_attrs(*args, **kwargs)
+        attrs["data-controller"] = "instance-selector"
+        attrs["data-instance-selector-config-value"] = json.dumps(
+            self.get_js_config(self.id_, self.name)
+        )
+        return attrs
 
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
-
-            embed_url = reverse(
-                "wagtail_instance_selector_embed",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-            # We use the input name for the embed id so that wagtail's block code will automatically
-            # replace any `__prefix__` substring with a specific id for the widget instance
-            embed_id = name
-            embed_url += "#instance_selector_embed_id:" + embed_id
-
-            lookup_url = reverse(
-                "wagtail_instance_selector_lookup",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-
-            return render_to_string(
-                "instance_selector/instance_selector_widget.html",
-                {
-                    "name": name,
-                    "is_nonempty": value_data["pk"] is not None,
-                    "widget": self,
-                    "widget_id": "%s-instance-selector-widget" % attrs["id"],
-                    "original_field_html": original_field_html,
-                    "display_markup": value_data["display_markup"],
-                    "edit_url": value_data["edit_url"],
-                },
-            )
-
-        def get_js_config(self, id_, name):
-            app_label = self.target_model._meta.app_label
-            model_name = self.target_model._meta.model_name
-
-            embed_url = reverse(
-                "wagtail_instance_selector_embed",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-            # We use the input name for the embed id so that wagtail's block code will automatically
-            # replace any `__prefix__` substring with a specific id for the widget instance
-            embed_id = name
-            embed_url += "#instance_selector_embed_id:" + embed_id
-
-            lookup_url = reverse(
-                "wagtail_instance_selector_lookup",
-                kwargs={"app_label": app_label, "model_name": model_name},
-            )
-
-            return {
-                "input_id": id_,
-                "widget_id": "%s-instance-selector-widget" % id_,
-                "field_name": name,
-                "embed_url": embed_url,
-                "embed_id": embed_id,
-                "lookup_url": lookup_url,
-                "OBJECT_PK_PARAM": OBJECT_PK_PARAM,
-            }
-
-        def render_js_init(self, id_, name, value):
-            config = self.get_js_config(id_, name)
-            return "create_instance_selector_widget({config});".format(
-                config=json.dumps(config)
-            )
+    @property
+    def media(self):
+        return Media(
+            js=[
+                "instance_selector/instance-selector-controller.js",
+            ]
+        )
 
 
 class InstanceSelectorAdapter(WidgetAdapter):

--- a/instance_selector/widgets.py
+++ b/instance_selector/widgets.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.telepath import register
-from wagtail.utils.widgets import WidgetWithScript
 from wagtail.widget_adapters import WidgetAdapter
 
 from instance_selector.constants import OBJECT_PK_PARAM
@@ -161,7 +160,7 @@ if WAGTAIL_VERSION >= (6, 0):
             )
 
 else:
-
+    from wagtail.utils.widgets import WidgetWithScript
     class InstanceSelectorWidget(WidgetWithScript, widgets.Input):
         # when looping over form fields, this one should appear in visible_fields, not hidden_fields
         # despite the underlying input being type="hidden"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=3.2
 django-webtest>=1.9.5,<2.0
-wagtail>=4.1
+wagtail>=5.2
 black==19.10b0
 ipdb>=0.12,<1.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=3.2
 django-webtest>=1.9.5,<2.0
-wagtail>=5.2
+wagtail>=6.3
 black==24.3.0
 ipdb>=0.12,<1.0
 

--- a/runtests.py
+++ b/runtests.py
@@ -1,4 +1,5 @@
 import sys
+
 from django.conf import settings
 
 settings.configure(
@@ -16,7 +17,7 @@ settings.configure(
             "django.contrib.messages",
             "wagtail.admin",
             "wagtail",
-            "wagtail.contrib.modeladmin",
+            "wagtail_modeladmin",
             "wagtail.contrib.settings",
             "wagtail.users",
             "wagtail.documents",

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 import instance_selector
 
 
-install_requires = ["wagtail>=4.1"]
-testing_requires = ["django_webtest"]
+install_requires = ["wagtail>=5.2"]
+testing_requires = ["django_webtest", "wagtail_modeladmin"]
 
 setup(
     name="wagtail-instance-selector",
@@ -22,11 +22,11 @@ setup(
             "Environment :: Web Environment",
             "Framework :: Django",
             "Framework :: Django :: 3.2",
-            "Framework :: Django :: 4.1",
             "Framework :: Django :: 4.2",
+            "Framework :: Django :: 5.0",
             "Framework :: Wagtail",
-            "Framework :: Wagtail :: 4",
             "Framework :: Wagtail :: 5",
+            "Framework :: Wagtail :: 6",
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
             "Programming Language :: Python",
@@ -35,6 +35,7 @@ setup(
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
+            "Programming Language :: Python :: 3.12",
             "Topic :: Utilities",
         ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 import instance_selector
 
 
-install_requires = ["wagtail>=5.2"]
-testing_requires = ["django_webtest", "wagtail_modeladmin"]
+install_requires = ["wagtail>=5.2", "wagtail-modeladmin"]
+testing_requires = ["django_webtest"]
 
 setup(
     name="wagtail-instance-selector",
@@ -23,15 +23,16 @@ setup(
             "Framework :: Django",
             "Framework :: Django :: 3.2",
             "Framework :: Django :: 4.2",
-            "Framework :: Django :: 5.0",
+            "Framework :: Django :: 5.1",
+            "Framework :: Django :: 5.2",
             "Framework :: Wagtail",
             "Framework :: Wagtail :: 5",
             "Framework :: Wagtail :: 6",
+            "Framework :: Wagtail :: 7",
             "License :: OSI Approved :: MIT License",
             "Operating System :: OS Independent",
             "Programming Language :: Python",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 import instance_selector
 
 
-install_requires = ["wagtail>=5.2", "wagtail-modeladmin"]
+install_requires = ["wagtail>=6.3", "wagtail-modeladmin"]
 testing_requires = ["django_webtest"]
 
 setup(
@@ -24,9 +24,7 @@ setup(
             "Framework :: Django :: 3.2",
             "Framework :: Django :: 4.2",
             "Framework :: Django :: 5.1",
-            "Framework :: Django :: 5.2",
             "Framework :: Wagtail",
-            "Framework :: Wagtail :: 5",
             "Framework :: Wagtail :: 6",
             "Framework :: Wagtail :: 7",
             "License :: OSI Approved :: MIT License",

--- a/tests/test_instance_selector.py
+++ b/tests/test_instance_selector.py
@@ -1,19 +1,17 @@
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django_webtest import WebTest
-from django.contrib.auth import get_user_model
+from wagtail import VERSION as WAGTAIL_VERSION
 
 from instance_selector.constants import OBJECT_PK_PARAM
 from instance_selector.registry import registry
-from instance_selector.selectors import (
-    BaseInstanceSelector,
-    ModelAdminInstanceSelector,
-    WagtailUserInstanceSelector,
-)
+from instance_selector.selectors import (BaseInstanceSelector,
+                                         ModelAdminInstanceSelector,
+                                         WagtailUserInstanceSelector)
+
 from .test_project.test_app.models import TestModelA, TestModelB, TestModelC
-from .test_project.test_app.wagtail_hooks import (
-    TestModelAAdmin,
-    TestModelBAdmin,
-)
+from .test_project.test_app.wagtail_hooks import (TestModelAAdmin,
+                                                  TestModelBAdmin)
 
 User = get_user_model()
 
@@ -21,10 +19,11 @@ User = get_user_model()
 class Tests(WebTest):
     """
     Commented out tests are failing for the Wagtail 4.0 + releases.
-    
+
     Im not sure how relevant they are now that the widgets are being rendered
     by javascript.
     """
+
     def setUp(self):
         TestModelA.objects.all().delete()
         TestModelB.objects.all().delete()
@@ -68,9 +67,9 @@ class Tests(WebTest):
 
     def test_widget_renders_during_model_creation(self):
         res = self.app.get("/admin/test_app/testmodelb/create/", user=self.superuser)
-        self.assertIn('/static/instance_selector/instance_selector.css', res.text)
-        self.assertIn('/static/instance_selector/instance_selector_embed.js', res.text)
-        self.assertIn('/static/instance_selector/instance_selector_widget.js', res.text)
+        self.assertIn("/static/instance_selector/instance_selector.css", res.text)
+        self.assertIn("/static/instance_selector/instance_selector_embed.js", res.text)
+        self.assertIn("/static/instance_selector/instance_selector_widget.js", res.text)
         # leaving these commented out for now, as the widget is now rendered by javascript
         # and they may be useful to decide how relevant they are now.
         # self.assertIn('class="instance-selector-widget ', res.text)
@@ -81,9 +80,9 @@ class Tests(WebTest):
         res = self.app.get(
             "/admin/test_app/testmodelb/edit/%s/" % b.pk, user=self.superuser
         )
-        self.assertIn('/static/instance_selector/instance_selector.css', res.text)
-        self.assertIn('/static/instance_selector/instance_selector_embed.js', res.text)
-        self.assertIn('/static/instance_selector/instance_selector_widget.js', res.text)
+        self.assertIn("/static/instance_selector/instance_selector.css", res.text)
+        self.assertIn("/static/instance_selector/instance_selector_embed.js", res.text)
+        self.assertIn("/static/instance_selector/instance_selector_widget.js", res.text)
         # leaving these commented out for now, as the widget is now rendered by javascript
         # and they may be useful to decide how relevant they are now.
         # self.assertIn('class="instance-selector-widget ', res.text)
@@ -95,11 +94,20 @@ class Tests(WebTest):
         res = self.app.get(
             "/admin/test_app/testmodelb/edit/%s/" % b.pk, user=self.superuser
         )
-        self.assertIn(
-            '<input type="hidden" name="test_model_a" value="%s" id="id_test_model_a">'
-            % a.pk,
-            res.text,
-        )
+
+        if WAGTAIL_VERSION >= (6, 0):
+            from html import escape
+
+            self.assertIn(
+                '<input type="hidden" name="test_model_a" value="1" id="id_test_model_a" data-controller="instance-selector" data-instance-selector-config-value="{&quot;input_id&quot;: &quot;id_test_model_a&quot;, &quot;widget_id&quot;: &quot;id_test_model_a-instance-selector-widget&quot;, &quot;field_name&quot;: &quot;test_model_a&quot;, &quot;embed_url&quot;: &quot;/admin/instance-selector/embed/test_app.testmodela/#instance_selector_embed_id:test_model_a&quot;, &quot;embed_id&quot;: &quot;test_model_a&quot;, &quot;lookup_url&quot;: &quot;/admin/instance-selector/lookup/test_app.testmodela/&quot;, &quot;OBJECT_PK_PARAM&quot;: &quot;object_pk&quot;}">',
+                res.text,
+            )
+        else:
+            self.assertIn(
+                '<input type="hidden" name="test_model_a" value="%s" id="id_test_model_a">'
+                % a.pk,
+                res.text,
+            )
         self.assertIn(
             '<span class="instance-selector-widget__display__title">TestModelA object (%s)</span>'
             % a.pk,
@@ -126,15 +134,15 @@ class Tests(WebTest):
             "/admin/test_app/testmodelb/edit/%s/" % b.pk, user=self.superuser
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector.css',
+            "/static/instance_selector/instance_selector.css",
             res.text,
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector_embed.js',
+            "/static/instance_selector/instance_selector_embed.js",
             res.text,
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector_widget.js',
+            "/static/instance_selector/instance_selector_widget.js",
             res.text,
         )
         # leaving these commented out for now, as the widget is now rendered by javascript
@@ -162,15 +170,15 @@ class Tests(WebTest):
             "/admin/test_app/testmodelb/edit/%s/" % b.pk, user=self.superuser
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector.css',
+            "/static/instance_selector/instance_selector.css",
             res.text,
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector_embed.js',
+            "/static/instance_selector/instance_selector_embed.js",
             res.text,
         )
         self.assertIn(
-            '/static/instance_selector/instance_selector_widget.js',
+            "/static/instance_selector/instance_selector_widget.js",
             res.text,
         )
         # leaving this commented out for now, as the widget is now rendered by javascript

--- a/tests/test_instance_selector.py
+++ b/tests/test_instance_selector.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from django_webtest import WebTest
-from wagtail import VERSION as WAGTAIL_VERSION
 
 from instance_selector.constants import OBJECT_PK_PARAM
 from instance_selector.registry import registry
@@ -95,19 +94,11 @@ class Tests(WebTest):
             "/admin/test_app/testmodelb/edit/%s/" % b.pk, user=self.superuser
         )
 
-        if WAGTAIL_VERSION >= (6, 0):
-            from html import escape
+        self.assertIn(
+            '<input type="hidden" name="test_model_a" value="1" id="id_test_model_a" data-controller="instance-selector" data-instance-selector-config-value="{&quot;input_id&quot;: &quot;id_test_model_a&quot;, &quot;widget_id&quot;: &quot;id_test_model_a-instance-selector-widget&quot;, &quot;field_name&quot;: &quot;test_model_a&quot;, &quot;embed_url&quot;: &quot;/admin/instance-selector/embed/test_app.testmodela/#instance_selector_embed_id:test_model_a&quot;, &quot;embed_id&quot;: &quot;test_model_a&quot;, &quot;lookup_url&quot;: &quot;/admin/instance-selector/lookup/test_app.testmodela/&quot;, &quot;OBJECT_PK_PARAM&quot;: &quot;object_pk&quot;}">',
+            res.text,
+        )
 
-            self.assertIn(
-                '<input type="hidden" name="test_model_a" value="1" id="id_test_model_a" data-controller="instance-selector" data-instance-selector-config-value="{&quot;input_id&quot;: &quot;id_test_model_a&quot;, &quot;widget_id&quot;: &quot;id_test_model_a-instance-selector-widget&quot;, &quot;field_name&quot;: &quot;test_model_a&quot;, &quot;embed_url&quot;: &quot;/admin/instance-selector/embed/test_app.testmodela/#instance_selector_embed_id:test_model_a&quot;, &quot;embed_id&quot;: &quot;test_model_a&quot;, &quot;lookup_url&quot;: &quot;/admin/instance-selector/lookup/test_app.testmodela/&quot;, &quot;OBJECT_PK_PARAM&quot;: &quot;object_pk&quot;}">',
-                res.text,
-            )
-        else:
-            self.assertIn(
-                '<input type="hidden" name="test_model_a" value="%s" id="id_test_model_a">'
-                % a.pk,
-                res.text,
-            )
         self.assertIn(
             '<span class="instance-selector-widget__display__title">TestModelA object (%s)</span>'
             % a.pk,

--- a/tests/test_instance_selector.py
+++ b/tests/test_instance_selector.py
@@ -277,13 +277,35 @@ class Tests(WebTest):
             res.text,
         )
 
+    """
+    <div id="body" data-block data-controller="w-block" data-w-block-data-value="{"_type": "wagtail.blocks.StreamBlock", "_args": ["", [["", [{"_type": "wagtail.blocks.FieldBlock", "_args": ["test", {"_type": "wagtail.widgets.Widget", "_args": ["<input type=\"text\" name=\"__NAME__\" id=\"__ID__\">", "__ID__"]}, {"label": "Test", "description": "", "required": true, "icon": "placeholder", "blockDefId": "blockdef-0", "isPreviewable": false, "classname": "w-field w-field--model_choice_field w-field--text_input", "showAddCommentButton": true, "strings": {"ADD_COMMENT": "Add Comment"}}]}]]], {"test": {"pk": null, "display_markup": "<div class=\"instance-selector-widget__display instance-selector-widget__display--no-image\">\n    <div class=\"instance-selector-widget__display__image-wrap\">\n        <a\n            href=\"None\"\n            class=\"instance-selector-widget__display__edit-link instance-selector-widget__display__edit-link--image js-instance-selector-widget-display-edit-link\"\n            target=\"_blank\"\n        >\n            <img\n                \n                class=\"instance-selector-widget__display__image\"\n                \n                    style=\"max-width: 165px; max-height: 165px; \"\n                \n            >\n        </a>\n    </div>\n    <div class=\"instance-selector-widget__display__title-wrap\">\n        <a\n            href=\"None\"\n            class=\"instance-selector-widget__display__edit-link instance-selector-widget__display__edit-link--title js-instance-selector-widget-display-edit-link\"\n            target=\"_blank\"\n        >\n            <span class=\"instance-selector-widget__display__title\">None</span>\n        </a>\n    </div>\n</div>\n", "edit_url": null}}, {"label": "", "description": "", "required": true, "icon": "placeholder", "blockDefId": "blockdef-1", "isPreviewable": false, "classname": null, "maxNum": null, "minNum": null, "blockCounts": {}, "collapsed": false, "strings": {"MOVE_UP": "Move up", "MOVE_DOWN": "Move down", "DRAG": "Drag", "DUPLICATE": "Duplicate", "DELETE": "Delete", "ADD": "Add"}}]}" data-w-block-arguments-value="[[],null]"></div>
+    """
+
+
     def test_blocks_can_render_widget_code(self):
+        from bs4 import BeautifulSoup
         c = TestModelC.objects.create()
         res = self.app.get(
             "/admin/test_app/testmodelc/edit/%s/" % c.pk, user=self.superuser
         )
+        soup = BeautifulSoup(res.text, "html.parser")
+        body = soup.find(id="body")
+        
+        self.assertIsNotNone(body)
+        
         # rendered widget output is embedded in JSON within the data-block attribute
+        self.assertIn("data-block", body.attrs)
+        self.assertIn("data-controller", body.attrs)
+        self.assertIn("data-w-block-data-value", body.attrs)
+        self.assertIn("data-w-block-arguments-value", body.attrs)
+        
+        # look for required true in the JSON data-block attribute
         self.assertIn(
-            "class=\&quot;instance-selector-widget instance-selector-widget--unselected instance-selector-widget--required\&quot;",
-            res.text,
+            '"required": true,', body.attrs["data-w-block-data-value"]
+        )
+
+        # look for class=\"instance-selector-widget__display\" in the JSON data-block attribute
+        self.assertIn(
+            '"display_markup": "<div class=\\"instance-selector-widget__display instance-selector-widget__display--no-image\\"',
+            body.attrs["data-w-block-data-value"],
         )

--- a/tests/test_instance_selector.py
+++ b/tests/test_instance_selector.py
@@ -268,11 +268,6 @@ class Tests(WebTest):
             res.text,
         )
 
-    """
-    <div id="body" data-block data-controller="w-block" data-w-block-data-value="{"_type": "wagtail.blocks.StreamBlock", "_args": ["", [["", [{"_type": "wagtail.blocks.FieldBlock", "_args": ["test", {"_type": "wagtail.widgets.Widget", "_args": ["<input type=\"text\" name=\"__NAME__\" id=\"__ID__\">", "__ID__"]}, {"label": "Test", "description": "", "required": true, "icon": "placeholder", "blockDefId": "blockdef-0", "isPreviewable": false, "classname": "w-field w-field--model_choice_field w-field--text_input", "showAddCommentButton": true, "strings": {"ADD_COMMENT": "Add Comment"}}]}]]], {"test": {"pk": null, "display_markup": "<div class=\"instance-selector-widget__display instance-selector-widget__display--no-image\">\n    <div class=\"instance-selector-widget__display__image-wrap\">\n        <a\n            href=\"None\"\n            class=\"instance-selector-widget__display__edit-link instance-selector-widget__display__edit-link--image js-instance-selector-widget-display-edit-link\"\n            target=\"_blank\"\n        >\n            <img\n                \n                class=\"instance-selector-widget__display__image\"\n                \n                    style=\"max-width: 165px; max-height: 165px; \"\n                \n            >\n        </a>\n    </div>\n    <div class=\"instance-selector-widget__display__title-wrap\">\n        <a\n            href=\"None\"\n            class=\"instance-selector-widget__display__edit-link instance-selector-widget__display__edit-link--title js-instance-selector-widget-display-edit-link\"\n            target=\"_blank\"\n        >\n            <span class=\"instance-selector-widget__display__title\">None</span>\n        </a>\n    </div>\n</div>\n", "edit_url": null}}, {"label": "", "description": "", "required": true, "icon": "placeholder", "blockDefId": "blockdef-1", "isPreviewable": false, "classname": null, "maxNum": null, "minNum": null, "blockCounts": {}, "collapsed": false, "strings": {"MOVE_UP": "Move up", "MOVE_DOWN": "Move down", "DRAG": "Drag", "DUPLICATE": "Duplicate", "DELETE": "Delete", "ADD": "Add"}}]}" data-w-block-arguments-value="[[],null]"></div>
-    """
-
-
     def test_blocks_can_render_widget_code(self):
         from bs4 import BeautifulSoup
         c = TestModelC.objects.create()

--- a/tests/test_project/test_app/__init__.py
+++ b/tests/test_project/test_app/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "%s.apps.AppConfig" % __name__

--- a/tests/test_project/test_app/wagtail_hooks.py
+++ b/tests/test_project/test_app/wagtail_hooks.py
@@ -1,4 +1,5 @@
-from wagtail.contrib.modeladmin.options import ModelAdmin, modeladmin_register
+from wagtail_modeladmin.options import ModelAdmin, modeladmin_register
+
 from .models import TestModelA, TestModelB, TestModelC
 
 


### PR DESCRIPTION
[Support ticket](https://torchbox.monday.com/boards/1124794299/pulses/1396935126)

## This work has been repurposed for supporting Wagtail 6.3+

### Compatibility Updates:
* Replaced `wagtail.contrib.modeladmin` with `wagtail_modeladmin` across multiple files to reflect the new library structure. 
* Updated `requirements.txt` to require `wagtail>=6.3` and added `wagtail-modeladmin>=2.0`.
* Adjusted `setup.py` to reflect compatibility with Wagtail 6 and 7, Django 5.1, and Python 3.12.

### Refactoring for Instance Selector Widget:
* Refactored `InstanceSelectorWidget` to use Stimulus controllers for JavaScript initialization, removing the previous `WidgetWithScript` dependency. 
* Added a new JavaScript controller for `instance_selector`, enabling dynamic widget creation via Stimulus. 
* Modified `InstanceSelectorBlock` to simplify widget initialization and satisfy Wagtail internals. 

### Testing and Code Cleanup:
* Updated test cases to reflect changes in widget rendering, ensuring compatibility with the new Stimulus-based approach. 
Fixes `The test_blocks_can_render_widget_code test case is failing with the error` below

---

## The below work was left intact except where above adjustments have been made

## [Wagtail 6.0 release notes](https://docs.wagtail.org/en/stable/releases/6.0.html)

### Summary of changes

- Added Wagtail 6.0 compatibility
- Added tests for Django 5.0
- Added tests for Python 3.12
- [Replace deprecated wagtail.contrib.modeladmin with wagtail_modeladmin](https://github.com/torchbox-forks/wagtail-instance-selector/pull/7/commits/63555c4e5dac7072d3b8da81fc16c7ee27726244)
- [Wagtail 6.0 upgrade consideration: Deprecated WidgetWithScript base widget class](https://github.com/torchbox-forks/wagtail-instance-selector/pull/7/commits/c66782e65e205b10c95467d656e489b60c703a0c)

### Current blocker

- The `test_blocks_can_render_widget_code` test case is failing with the error

```
AttributeError at /admin/example_app/product/create/
'BlockWidget' object has no attribute '_block_json'
```

The issue is similar to this one:
https://github.com/labd/wagtailstreamforms/issues/200

There might have been a rework on the `ChooserWidget` or a deprecation which took effect on Wagtail v6.0